### PR TITLE
(fix) Install modules with post-install scripts

### DIFF
--- a/lib/yanpm.js
+++ b/lib/yanpm.js
@@ -725,7 +725,7 @@ Yanpm.prototype._installPlugins = function () {
     for(var i = 0; i < this._pluginConfigs.length; i++) {
         packages.push( this._pluginConfigs[i].package );
     }
-    packages.push('--json');
+    packages.push('--silent', '--json');
     //this._logger.log("Install Plugins:", packages);
 
 

--- a/test/functional/tests/config.js
+++ b/test/functional/tests/config.js
@@ -49,6 +49,24 @@ module.exports = [
             });
         }
     },
+    {
+        name: "use install for modules with post-install scripts (e.g. electron, sqlite3)",
+        func: function(ya, done) {
+            ya.install("electron").then(function(){
+                expect( ya.errors() ).to.be.null;
+
+                var electron = ya.get('electron');
+                expect(electron).to.not.be.null;
+
+                if (done) done();
+            }, function(err){
+                console.error('Error:', err);
+                expect( err ).to.be.null;
+
+                if(done) done();
+            });
+        }
+    },
     // -------------------------------------
     {
         name: "args - * group, name and package the same",


### PR DESCRIPTION
Modules with post-install scripts (e.g. sqlite3, electron) don't output valid json when using the `--json` flag:

```sh
npm install electron --json 2>/dev/null
```
```
> electron@1.6.2 postinstall /Users/michhart/Desktop/projects/yanpm/node_modules/electron
> node install.js

{
  "name": "yanpm",
  "version": "1.0.0",
  "dependencies": {
    "electron": {
      "version": "1.6.2",
      "from": "electron@latest",
      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.2.tgz"
    }
  }
}
```

Adding the `--silent` flag will get rid of the postinstall output:

```sh
npm install electron --silent --json 2>/dev/null
```
```
{
  "name": "yanpm",
  "version": "1.0.0",
  "dependencies": {
    "electron": {
      "version": "1.6.2",
      "from": "electron@latest",
      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.2.tgz"
    }
  }
}
```