### PR TITLE
(fix) Install modules where one module name is a substring of the other

### DIFF
--- a/lib/yanpm.js
+++ b/lib/yanpm.js
@@ -4,6 +4,7 @@
 'use strict';
 
 var path  = require('path');
+var url   = require('url');
 var spawn = require('child_process').spawn;
 var Q     = require('q');
 
@@ -47,6 +48,29 @@ function getPackageName(pack) {
     }
 }
 
+function getPackageNameFromUrl(packageUrl) {
+    if (typeof packageUrl !== 'string') {
+        return null;
+    }
+
+    var u = url.parse(packageUrl);
+    if (u.protocol === null || u.host === null || u.pathname === null) {
+        return null;
+    }
+
+    var pathname = u.pathname;
+
+    // "/lodash/lodash.git" --> "lodash.git"
+    pathname = pathname.split('/').slice(-1).join('/');
+
+    // "lodash.git" --> "lodash"
+    if (pathname.slice(-4) === '.git') {
+        pathname = pathname.slice(0, -4);
+    }
+
+    return pathname;
+}
+
 function getPackageVersion(pack) {
     var atPos = pack.indexOf('@');
     if (atPos < 1) {
@@ -65,7 +89,13 @@ function requireRemoveCache(moduleDir) {
 
         // Remove cached paths to the module.
         Object.keys(mod.constructor._pathCache).forEach(function(cacheKey) {
-            if (cacheKey.indexOf(moduleDir) > 0) {
+            var parsedCacheKey = null;
+            try {
+                parsedCacheKey = JSON.parse(cacheKey);
+            } catch(e) {
+            }
+
+            if (parsedCacheKey && parsedCacheKey.request === moduleDir) {
                 delete mod.constructor._pathCache[cacheKey];
             }
         });
@@ -778,10 +808,10 @@ Yanpm.prototype._installPlugins = function () {
         // TODO: attach config to particular plugin
         for(var i = 0; i < this._pluginConfigs.length; i++) {
             for(var j = 0; j < installed.length; j++) {
-
                 if( (this._pluginConfigs[i].package === installed[j].from) ||
                     (this._pluginConfigs[i].name === installed[j].name) ||
-                    (this._pluginConfigs[i].package.indexOf(installed[j].name) >= 0)
+                    (this._pluginConfigs[i].package === installed[j].name) ||
+                    (getPackageNameFromUrl(this._pluginConfigs[i].package) === installed[j].name)
                 ) {
                     this._pluginConfigs[i].packageName = installed[j].name;
 

--- a/test/functional/tests/config.js
+++ b/test/functional/tests/config.js
@@ -49,6 +49,27 @@ module.exports = [
             });
         }
     },
+    {
+        name: "use install for modules where one name is a substring of the other (e.g. lod, lodash)",
+        func: function (ya, done) {
+            ya.add(['lod', 'lodash']);
+            ya.install().then(function(){
+                expect( ya.errors() ).to.be.null;
+
+                var lod = ya.get('lod');
+                var lodash = ya.get('lodash');
+
+                expect(lod).to.not.be.null;
+                expect(lodash).to.not.be.null;
+                expect(lod).to.not.equal(lodash);
+
+                if(done) done();
+            }).catch(function(err){
+                console.error('Error:', err);
+                if(done) done(err);
+            });
+        }
+    },
     // -------------------------------------
     {
         name: "args - * group, name and package the same",


### PR DESCRIPTION
Modules don't install or clean up correctly when `a !== b` but `a.indexOf(b) === 0`

e.g. when `a = 'lodash'` and `b = 'lod'`
```js
ya.add(['lod', 'lodash']);
yield ya.install();

var lod = ya.get('lod'); // correct
var lodash = ya.get('lodash'); // null
```